### PR TITLE
chimee-plugin-controlbar v0.5.0这个版本影响依赖安装速度

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chimee-kernel-hls": "^1.3.2",
     "chimee-plugin-center-state": "0.0.14",
     "chimee-plugin-contextmenu": "^0.1.2",
-    "chimee-plugin-controlbar": "^0.5.0",
+    "chimee-plugin-controlbar": "^0.4.11",
     "chimee-plugin-log": "0.0.4",
     "chimee-plugin-popup": "0.0.8"
   },


### PR DESCRIPTION
chimee-plugin-controlbar v0.5.0中依赖的chimee-helper是从github地址安装，非常影响拉包速度，所以降级回v0.4.11
`  "dependencies": {
    "chimee-helper": "git+https://github.com/Chimeejs/chimee-helper.git"
  },`